### PR TITLE
Label OWM as requiring an API key.

### DIFF
--- a/settings-schema.json
+++ b/settings-schema.json
@@ -10,7 +10,7 @@
     "description" : "Data service",
     "options" : {
         "BBC" : "bbc",
-        "Open Weather Map": "owm",
+        "Open Weather Map (requires API key)": "owm",
         "Wunderground (requires API key)": "wunderground",
         "World Weather Online (requires API key)": "wwo",
         "Forecast.io (requires API key)" : "forecast",


### PR DESCRIPTION
I live in the U.S. so I tried using OpenWeatherMap rather than BBC.  Found out that I [needed an API key](http://openweathermap.org/appid) even though the options made it seem like I didn't.